### PR TITLE
Change save items use case to operate item by item 

### DIFF
--- a/lib/builder/items.rb
+++ b/lib/builder/items.rb
@@ -1,39 +1,27 @@
 # frozen_string_literal: true
 
-module ItemBuilder
+module Builder
   class Item
-    attr_accessor :items,
-                  :id,
-                  :name,
-                  :price,
-                  :quantity
-
     def build
-      copy_from_individual_fields unless items_exist?
-      items.map! do |part|
-        item = ::Item.new
-        item.id = part[:id]
-        item.name = part[:name]
-        item.price = part[:price]
-        item.quantity = part[:quantity]
-        item
-      end
-      items
+      item = ::Item.new
+      item.id = item_details[:id]
+      item.name = item_details[:name]
+      item.price = item_details[:price]
+      item.quantity = item_details[:quantity]
+      item
     end
 
-    private
-
-    def items_exist?
-      !items.nil?
-    end
-
-    def copy_from_individual_fields
-      @items = {
+    def from(id:, name:, price:, quantity: )
+      @item_details = {
         id: id,
         name: name,
         price: price,
         quantity: quantity
       }
     end
+
+    private
+
+    attr_accessor :item_details
   end
 end

--- a/lib/file_items_gateway.rb
+++ b/lib/file_items_gateway.rb
@@ -7,24 +7,34 @@ class FileItemsGateway
 
   def all
     return [] unless File.exist?(FILE_PATH)
-    File.open(FILE_PATH, 'r') do |file|
-      item_builder = ItemBuilder::Item.new
-      item_builder.items = JSON.parse(file.read, symbolize_names: true)
-      [item_builder.build]
+    items = File.open(FILE_PATH, 'r') do |file|
+      JSON.parse(file.read, symbolize_names: true)
     end
+
+    items.map! do |item_details|
+      item_builder = Builder::Item.new
+      item_builder.from(
+        id: item_details[:id],
+        name: item_details[:name],
+        price: item_details[:price],
+        quantity: item_details[:quantity]
+      )
+      item_builder.build
+    end
+    items
   end
 
-  def save(item)
-    item.map! do |part|
+  def save(items)
+    items.map! do |item|
       {
-        id: part.id,
-        name: part.name,
-        price: part.price,
-        quantity: part.quantity
+        id: item.id,
+        name: item.name,
+        price: item.price,
+        quantity: item.quantity
       }
     end
     File.open(FILE_PATH, 'w') do |file|
-      file.write(item.to_json)
+      file.write(items.to_json)
     end
   end
 

--- a/lib/use_cases/save_items_details.rb
+++ b/lib/use_cases/save_items_details.rb
@@ -5,17 +5,24 @@ class SaveItemsDetails
     @items_gateway = items_gateway
   end
 
-  def execute(items:)
-    @items = items
-
+  def execute(item_details:)
+    @item_details = item_details
     errors = validation
 
     return { successful: false, errors: errors } unless errors.empty?
 
-    item_builder = ItemBuilder::Item.new
-    item_builder.items = @items
+    item_builder = Builder::Item.new
+    item_builder.from(
+      id: @item_details[:id],
+      name: @item_details[:name],
+      price: @item_details[:price],
+      quantity: @item_details[:quantity]
+    ) 
 
-    @items_gateway.save(item_builder.build)
+    all_items = @items_gateway.all
+    all_items.push(item_builder.build)
+
+    @items_gateway.save(all_items)
 
     { successful: true, errors: [] }
   end
@@ -23,18 +30,13 @@ class SaveItemsDetails
   private
 
   def validation
-    errors = []
-    errors.push(missing_fields)
-    errors = errors.flatten(1)
-    errors
+    missing_fields
   end
 
   def missing_fields
     errors = []
-    @items.each_with_index do |row, index|
-      row.each_key do |column|
-        errors.push([:"missing_#{column}", index]) if @items[index][column].empty?
-      end
+    @item_details.each_key do |key|
+      errors.push(:"missing_#{key}") if @item_details[key].empty?
     end
     errors
   end

--- a/lib/use_cases/view_summary.rb
+++ b/lib/use_cases/view_summary.rb
@@ -9,30 +9,30 @@ class ViewSummary
   def execute
     { customer: customer, items: items }
   end
-  
+
   private
-  
+
   def customer
     customer = @customer_gateway.all.first
     { customer_name: customer.customer_name,
-    shipping_address_line1: customer.shipping_address_line1,
-    shipping_address_line2: customer.shipping_address_line2,
-    shipping_city: customer.shipping_city,
-    shipping_county: customer.shipping_county,
-    shipping_postcode: customer.shipping_postcode,
-    shipping_phone_number: customer.shipping_phone_number,
-    shipping_email_address: customer.shipping_email_address,
-    billing_address_line1: customer.billing_address_line1,
-    billing_address_line2: customer.billing_address_line2,
-    billing_city: customer.billing_city,
-    billing_county: customer.billing_county,
-    billing_postcode: customer.billing_postcode,
-    billing_phone_number: customer.billing_phone_number,
-    billing_email_address: customer.billing_email_address }
+      shipping_address_line1: customer.shipping_address_line1,
+      shipping_address_line2: customer.shipping_address_line2,
+      shipping_city: customer.shipping_city,
+      shipping_county: customer.shipping_county,
+      shipping_postcode: customer.shipping_postcode,
+      shipping_phone_number: customer.shipping_phone_number,
+      shipping_email_address: customer.shipping_email_address,
+      billing_address_line1: customer.billing_address_line1,
+      billing_address_line2: customer.billing_address_line2,
+      billing_city: customer.billing_city,
+      billing_county: customer.billing_county,
+      billing_postcode: customer.billing_postcode,
+      billing_phone_number: customer.billing_phone_number,
+      billing_email_address: customer.billing_email_address }
   end
-  
+
   def items
-    items = @items_gateway.all.first
+    items = @items_gateway.all
     items.map! do |item|
       {
         id: item.id,

--- a/lib/views/items_details.erb
+++ b/lib/views/items_details.erb
@@ -4,35 +4,6 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.0/js/bootstrap.min.js"></script>
     <script src="//code.jquery.com/jquery-1.11.1.min.js"></script>
-    <script>
-      $(document).ready(function () {
-      var counter = 0;
-
-      $("#addrow").on("click", function () {
-          var newRow = $("<tr>");
-          var cols = "";
-
-          cols += '<td><input type="text" class="form-control" name="id' + counter + '"/></td>';
-          cols += '<td><input type="text" class="form-control" name="name' + counter + '"/></td>';
-          cols += '<td><input type="text" class="form-control" name="price' + counter + '"/></td>';
-          cols += '<td><input type="text" class="form-control" name="quantity' + counter + '"/></td>';
-
-          cols += '<td><input type="button" class="ibtnDel btn btn-md btn-danger "  value="Delete"></td>';
-          newRow.append(cols);
-          $("table.order-list").append(newRow);
-          counter++;
-      });
-
-
-
-      $("table.order-list").on("click", ".ibtnDel", function (event) {
-          $(this).closest("tr").remove();
-          counter -= 1
-      });
-
-
-      });
-    </script>
   </head>
   <body>
     <div class="container p-3">
@@ -46,53 +17,52 @@
         <div class="col-2"></div>
       </div>
       <div class="row">
+        <div class="col-1"></div>
+        <div class="col-10">
+          <!--Content-->
+          <form method="POST" action="/add-item">
+            <div class="form-row">
+              <div class="col-2">
+                <label>ID</label>
+                <input type="text" id="id" name="id" class="form-control"/>
+              </div>
+              <div class="col-6">
+                <label>Item Name</label>
+                <input type="text" id="name" name="name" class="form-control"/>
+              </div>
+              <div class="col-2">
+                <label>Price</label>
+                <input type="text" id="price" name="price" class="form-control"/>
+              </div>
+              <div class="col-2">
+                <label>Quantity</label>
+                <input type="text" id="quantity" name="quantity" class="form-control"/>
+              </div>
+            </div>
+            <button type="submit" class="btn btn-primary pt-1 pb-1 float_right">Add</button>
+          </form>
+        </div>
+        <div class="col-1">
+        </div>
+      </div>
+      <div>
         <div class="col-2"></div>
         <div class="col-8">
-          <!--Content-->
-          <div class="container">
-            <table id="myTable" class=" table order-list">
-              <thead>
-                <tr>
-                  <td>ID</td>
-                  <td>Item Name</td>
-                  <td>Price</td>
-                  <td>Quantity</td>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="col-auto">
-                    <input type="text" name="id" class="form-control" />
-                  </td>
-                  <td class="col-auto">
-                    <input type="text" name="name"  class="form-control"/>
-                  </td>
-                  <td class="col-auto">
-                    <input type="text" name="price"  class="form-control"/>
-                  </td>
-                  <td class="col-auto">
-                    <input type="text" name="quantity"  class="form-control"/>
-                  </td>
-                  <td class="col-auto"><a class="deleteRow"></a>
-                  </td>
-                </tr>
-              </tbody>
-              <tfoot>
-                <tr>
-                  <td colspan="5" style="text-align: left;">
-                    <input type="button" class="btn btn-lg btn-block " id="addrow" value="Add Row" />
-                  </td>
-                </tr>
-                <tr>
-                </tr>
-              </tfoot>
-            </table>
-            <button type="submit" class="btn btn-primary pt-1 pb-1">Back</button>
-            <button type="submit" class="btn btn-primary pt-1 pb-1 float-right">Next</button>
-          </div>
+          <table class="table table-hover border rounded bg-white">
+            <tbody>
+              <% @items.each do |item| %>
+              <tr>
+                <td style="width: 10%;"><%= item[:id] %></td>
+                <td style="width: 40%;" ><%= item[:name] %></td>
+                <td style="width: 40%;" ><%= item[:price] %></td>
+                <td style="width: 10%;" > <span style="font-size: 15px; font-weight: normal;" class="badge badge-primary badge-pill"> <%= item[:quantity] %> </span>
+            </td>
+              </tr>
+              <% end %>
+            </tbody>
+          </table>
         </div>
-        <div class="col-2">
-        </div>
+        <div class="col-2"></div>
       </div>
     </div>
   </body>

--- a/spec/acceptance/place_order_spec.rb
+++ b/spec/acceptance/place_order_spec.rb
@@ -2,11 +2,13 @@
 
 require 'json'
 
-describe 'customer details' do
-  let(:file_customer_gateway) { FileCustomerGateway.new }
-  let(:file_items_gateway) { FileItemsGateway.new }
-  let(:save_customer_details) { SaveCustomerDetails.new(customer_gateway: file_customer_gateway) }
-  let(:save_items_details) { SaveItemsDetails.new(items_gateway: file_items_gateway) }
+describe 'place order' do
+  let(:customer_gateway) { FileCustomerGateway.new }
+  let(:items_gateway) { FileItemsGateway.new }
+  let(:save_customer_details) { SaveCustomerDetails.new(customer_gateway: customer_gateway) }
+  let(:save_items_details) { SaveItemsDetails.new(items_gateway: items_gateway) }
+
+  before(:each) { items_gateway.delete_all }
 
   context 'saving customer details' do
     context 'given valid customer details' do
@@ -31,7 +33,7 @@ describe 'customer details' do
 
         save_customer_details.execute(customer_details: customer_details)
 
-        customer = file_customer_gateway.all.first
+        customer = customer_gateway.all.first
         expect(customer.customer_name).to eq('Barry')
         expect(customer.shipping_address_line1).to eq('136 Southwark Street')
         expect(customer.shipping_address_line2).to eq('Southwark')
@@ -113,82 +115,72 @@ describe 'customer details' do
         billing_phone_number: '07912345671',
         billing_email_address: 'barry@gmail.com'
       }
-
-      items = [
-        { id: '456', name: 'Drones', price: '144', quantity: '34' },
-        { id: '454', name: 'Uranium', price: '130', quantity: '100' },
-        { id: '767', name: 'ACHSDJVHJDWVVFWVYEUVFW', price: '10', quantity: '200000' },
-        { id: '999', name: 'Screws', price: '0.9', quantity: '2000' }
-      ]
+      item1 = { id: '456', name: 'Drones', price: '144', quantity: '34' }
+      item2 = { id: '454', name: 'Uranium', price: '130', quantity: '100' }
+      item3 = { id: '767', name: 'ACHSDJVHJDWVVFWVYEUVFW', price: '10', quantity: '200000' }
+      item4 = { id: '999', name: 'Screws', price: '0.9', quantity: '2000' }
 
       save_customer_details.execute(customer_details: customer_details)
-      save_items_details.execute(items: items)
+      save_items_details.execute(item_details: item1)
+      save_items_details.execute(item_details: item2)
+      save_items_details.execute(item_details: item3)
+      save_items_details.execute(item_details: item4)
 
-      view_summary = ViewSummary.new(customer_gateway: file_customer_gateway, items_gateway: file_items_gateway)
+      view_summary = ViewSummary.new(customer_gateway: customer_gateway, items_gateway: items_gateway)
       response = view_summary.execute
-      expect(response).to eq(customer: customer_details, items: items)
-    end
-  end
-end
-
-describe 'add items' do
-  let(:items_gateway) { FileItemsGateway.new }
-  let(:save_items_details) { SaveItemsDetails.new(items_gateway: items_gateway) }
-
-  context 'given valid item detais' do
-    it 'stores the item details' do
-      ordered_items = [{
-        id: '123',
-        name: 'Bits',
-        price: '5.00',
-        quantity: '1'
-      }]
-      save_items_details.execute(items: ordered_items)
-
-      items = items_gateway.all.first
-
-      expect(items[0].id).to eq('123')
-      expect(items[0].name).to eq('Bits')
-      expect(items[0].price).to eq('5.00')
-      expect(items[0].quantity).to eq('1')
-    end
-
-    it 'stores the multiple items details' do
-      ordered_items = [
-        { id: '233', name: 'Bats', price: '12.00', quantity: '4' },
-        { id: '343', name: 'Buts', price: '17.00', quantity: '10' }
-      ]
-
-      save_items_details.execute(items: ordered_items)
-
-      items = items_gateway.all.first
-
-      expect(items[0].id).to eq('233')
-      expect(items[0].name).to eq('Bats')
-      expect(items[0].price).to eq('12.00')
-      expect(items[0].quantity).to eq('4')
-      expect(items[1].id).to eq('343')
-      expect(items[1].name).to eq('Buts')
-      expect(items[1].price).to eq('17.00')
-      expect(items[1].quantity).to eq('10')
+      expect(response).to eq(customer: customer_details, items: [item1, item2, item3, item4] )
     end
   end
 
-  context 'given invalid items details' do
-    it 'responds with a validation error' do
-      ordered_items = [
-        { id: '', name: '', price: '', quantity: '' }
-      ]
-      response = save_items_details.execute(items: ordered_items)
-      expect(response).to eq(
-        successful: false,
-        errors: [
-          [:missing_id, 0],
-          [:missing_name, 0],
-          [:missing_price, 0],
-          [:missing_quantity, 0]
-        ]
-      )
+  context 'add items' do
+    context 'given valid item detais' do
+      it 'stores the item details' do
+        item_ordered = { id: '123', name: 'Bits', price: '5.00', quantity: '1' }
+        save_items_details.execute(item_details: item_ordered)
+
+        item = items_gateway.all.first
+
+        expect(item.id).to eq('123')
+        expect(item.name).to eq('Bits')
+        expect(item.price).to eq('5.00')
+        expect(item.quantity).to eq('1')
+      end
+
+      it 'stores the multiple items details' do
+        ordered_item1 = { id: '233', name: 'Bats', price: '12.00', quantity: '4' }
+        ordered_item2 = { id: '343', name: 'Buts', price: '17.00', quantity: '10' }
+
+        save_items_details.execute(item_details: ordered_item1)
+        save_items_details.execute(item_details: ordered_item2)
+
+        items = items_gateway.all
+
+        expect(items[0].id).to eq('233')
+        expect(items[0].name).to eq('Bats')
+        expect(items[0].price).to eq('12.00')
+        expect(items[0].quantity).to eq('4')
+        expect(items[1].id).to eq('343')
+        expect(items[1].name).to eq('Buts')
+        expect(items[1].price).to eq('17.00')
+        expect(items[1].quantity).to eq('10')
+      end
+    end
+
+    context 'given invalid items details' do
+      it 'responds with a validation error' do
+        ordered_item = { id: '', name: '', price: '', quantity: '' }
+
+        response = save_items_details.execute(item_details: ordered_item)
+        expect(response).to eq(
+          successful: false,
+          errors: %i[
+            missing_id
+            missing_name
+            missing_price
+            missing_quantity
+          ]
+        )
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,9 @@ require 'capybara/dsl'
 require 'index'
 
 RSpec.configure do |config|
+  config.filter_run_when_matching :focus
+  config.run_all_when_everything_filtered
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/spec/unit/file_items_gateway_spec.rb
+++ b/spec/unit/file_items_gateway_spec.rb
@@ -12,19 +12,18 @@ describe FileItemsGateway do
   end
 
   it 'can get a row of item details' do
-    item_builder = ItemBuilder::Item.new
-    item_builder.items = [{
-      id: '108', name: 'Jeremy', price: '28.00', quantity: '1'
-    }]
+    item_builder = Builder::Item.new
+    item_builder.from(id: '108', name: 'Jeremy', price: '28.00', quantity: '1')
+ 
     item = item_builder.build
 
-    file_items_gateway.save(item)
+    file_items_gateway.save([item])
 
     file_items_gateway.all.first.tap do |items|
-      expect(items[0].id).to eq('108')
-      expect(items[0].name).to eq('Jeremy')
-      expect(items[0].price).to eq('28.00')
-      expect(items[0].quantity).to eq('1')
+      expect(items.id).to eq('108')
+      expect(items.name).to eq('Jeremy')
+      expect(items.price).to eq('28.00')
+      expect(items.quantity).to eq('1')
     end
   end
 end

--- a/spec/unit/use_cases/save_items_details_spec.rb
+++ b/spec/unit/use_cases/save_items_details_spec.rb
@@ -1,64 +1,39 @@
 # frozen_string_literal: true
 
 describe SaveItemsDetails do
-  let(:items_gateway) { spy }
-  let(:use_case) do
-    described_class.new(items_gateway: items_gateway)
-  end
+  let(:items_gateway) { spy(all: []) }
+  let(:dummy_item) { Class.new }
+  let(:use_case) { described_class.new(items_gateway: items_gateway) }
 
   it 'uses the items gateway to save the order details' do
-    use_case.execute(items: [{
-                       id: '456',
-                       name: 'Bots',
-                       price: '10.00',
-                       quantity: '2'
-                     }])
-    expect(items_gateway).to have_received(:save) do |items|
-      expect(items[0].id).to eq('456')
-      expect(items[0].name).to eq('Bots')
-      expect(items[0].price).to eq('10.00')
-      expect(items[0].quantity).to eq('2')
+    item = { id: '456', name: 'Bots', price: '10.00', quantity: '2' }
+    use_case.execute(item_details: item)
+    expect(items_gateway).to have_received(:save) do |item|
+      expect(item[0].id).to eq('456')
+      expect(item[0].name).to eq('Bots')
+      expect(item[0].price).to eq('10.00')
+      expect(item[0].quantity).to eq('2')
     end
   end
 
   it 'uses the items gateway to save multiple rows' do
-    items = [
-      { id: '999', name: 'Bobs', price: '99.00', quantity: '25' },
-      { id: '167', name: 'Lobs', price: '145.00', quantity: '3' }
-    ]
-    use_case.execute(items: items)
-    expect(items_gateway).to have_received(:save) do |items|
-      expect(items[0].id).to eq('999')
-      expect(items[0].name).to eq('Bobs')
-      expect(items[0].price).to eq('99.00')
-      expect(items[0].quantity).to eq('25')
-      expect(items[1].id).to eq('167')
-      expect(items[1].name).to eq('Lobs')
-      expect(items[1].price).to eq('145.00')
-      expect(items[1].quantity).to eq('3')
+    gateway = spy(all: [dummy_item])
+    item_use_case = described_class.new(items_gateway: gateway)
+    item = { id: '167', name: 'Lobs', price: '145.00', quantity: '3' }
+    item_use_case.execute(item_details: item)
+    expect(gateway).to have_received(:save) do |item|
+      expect(item[1].id).to eq('167')
+      expect(item[1].name).to eq('Lobs')
+      expect(item[1].price).to eq('145.00')
+      expect(item[1].quantity).to eq('3')
     end
   end
 
   it 'returns an error for missing id' do
-    response = use_case.execute(items: [
-                                  { id: '', name: 'Bobs', price: '10.00', quantity: '10' }
-                                ])
-    expect(response).to eq(successful: false,
-                           errors: [
-                             [:missing_id, 0]
-                           ])
-  end
-
-  it 'returns an error for multiple invalid rows' do
-    response = use_case.execute(items: [
-                                  { id: '14', name: '', price: '10.00', quantity: '10' },
-                                  { id: '', name: '', price: '10.00', quantity: '10' }
-                                ])
-    expect(response).to eq(successful: false,
-                           errors: [
-                             [:missing_name, 0],
-                             [:missing_id, 1],
-                             [:missing_name, 1]
-                           ])
+    response = use_case.execute(item_details: { id: '', name: 'Bobs', price: '10.00', quantity: '10' })
+    expect(response).to eq(
+      successful: false,
+      errors: [:missing_id]
+    )
   end
 end


### PR DESCRIPTION
WHY: We wanted to save items one by one so that they can be dynamically displayed in a table as users add more items.

(DISCLAIMER: we will rebase before merging, after making changes due to PR comments)