### PR TITLE
Update regex to include missing edge case

### DIFF
--- a/lib/use_cases/save_items_details.rb
+++ b/lib/use_cases/save_items_details.rb
@@ -52,6 +52,9 @@ class SaveItemsDetails
     @item_details[:quantity].match(QUANTITY_REGEX)
   end
 
-  PRICE_REGEX = /[0-9]+(\.[0-9]{2})?/
+  PRICE_REGEX = /(^\d+\.\d+$|^\d+$)/
+  # Any nubmer of digits, followed by a '.', followed by any number of digits
+  # OR
+  # Any number of digits
   QUANTITY_REGEX = /[0-9]+(\.[0-9]+)?/
 end

--- a/lib/use_cases/save_items_details.rb
+++ b/lib/use_cases/save_items_details.rb
@@ -52,9 +52,6 @@ class SaveItemsDetails
     @item_details[:quantity].match(QUANTITY_REGEX)
   end
 
-  PRICE_REGEX = /(^\d+\.\d+$|^\d+$)/
-  # Any nubmer of digits, followed by a '.', followed by any number of digits
-  # OR
-  # Any number of digits
+  PRICE_REGEX = /^[0-9]+(\.[0-9]+)?$/
   QUANTITY_REGEX = /[0-9]+(\.[0-9]+)?/
 end

--- a/lib/use_cases/save_items_details.rb
+++ b/lib/use_cases/save_items_details.rb
@@ -53,5 +53,5 @@ class SaveItemsDetails
   end
 
   PRICE_REGEX = /^[0-9]+(\.[0-9]+)?$/
-  QUANTITY_REGEX = /[0-9]+(\.[0-9]+)?/
+  QUANTITY_REGEX = /^[0-9]+(\.[0-9]+)?$/
 end

--- a/lib/views/items_details.erb
+++ b/lib/views/items_details.erb
@@ -82,18 +82,18 @@
                 <% if @errors.include?(:missing_price) || @errors.include?(:invalid_price)%>
                 <input type="text" pattern="^[0-9]+(\.[0-9]+)?$" id="price" name="price" class="form-control is-invalid" placeholder="Price"/>
                 <% elsif @item_row.nil? %>
-                <input type="text" id="price" name="price" class="form-control" placeholder="Price"/>
+                <input type="text" pattern="^[0-9]+(\.[0-9]+)?$" id="price" name="price" class="form-control" placeholder="Price"/>
                 <% else %>
-                <input type="text" id="price" name="price" class="form-control" value="<%= @item_row[:price]%>"/>
+                <input type="text" pattern="^[0-9]+(\.[0-9]+)?$" id="price" name="price" class="form-control" value="<%= @item_row[:price]%>"/>
                 <% end %>
               </div>
               <div class="p-1 width-11">
                 <%if @errors.include?(:missing_quantity) || @errors.include?(:invalid_quantity)%>
-                <input type="text" id="quantity" name="quantity" class="form-control is-invalid" placeholder="Quantity"/>
+                <input type="text" pattern="^[0-9]+(\.[0-9]+)?$" id="quantity" name="quantity" class="form-control is-invalid" placeholder="Quantity"/>
                 <% elsif @item_row.nil? %>
-                <input type="text" id="quantity" name="quantity" class="form-control" placeholder="Quantity"/>
+                <input type="text" pattern="^[0-9]+(\.[0-9]+)?$" id="quantity" name="quantity" class="form-control" placeholder="Quantity"/>
                 <% else %>
-                <input type="text" id="quantity" name="quantity" class="form-control" value="<%= @item_row[:quantity]%>"/>
+                <input type="text" pattern="^[0-9]+(\.[0-9]+)?$" id="quantity" name="quantity" class="form-control" value="<%= @item_row[:quantity]%>"/>
                 <% end %>
               </div>
               <div class="pl-5 pt-1 width-20">

--- a/lib/views/items_details.erb
+++ b/lib/views/items_details.erb
@@ -80,7 +80,7 @@
               </div>
               <div class="p-1 width-10">
                 <% if @errors.include?(:missing_price) || @errors.include?(:invalid_price)%>
-                <input type="text" id="price" name="price" class="form-control is-invalid" placeholder="Price"/>
+                <input type="text" pattern="(^\d+\.\d+$|^\d+$)" id="price" name="price" class="form-control is-invalid" placeholder="Price"/>
                 <% elsif @item_row.nil? %>
                 <input type="text" id="price" name="price" class="form-control" placeholder="Price"/>
                 <% else %>

--- a/lib/views/items_details.erb
+++ b/lib/views/items_details.erb
@@ -80,7 +80,7 @@
               </div>
               <div class="p-1 width-10">
                 <% if @errors.include?(:missing_price) || @errors.include?(:invalid_price)%>
-                <input type="text" pattern="(^\d+\.\d+$|^\d+$)" id="price" name="price" class="form-control is-invalid" placeholder="Price"/>
+                <input type="text" pattern="^[0-9]+(\.[0-9]+)?$" id="price" name="price" class="form-control is-invalid" placeholder="Price"/>
                 <% elsif @item_row.nil? %>
                 <input type="text" id="price" name="price" class="form-control" placeholder="Price"/>
                 <% else %>

--- a/spec/ui/items_details_spec.rb
+++ b/spec/ui/items_details_spec.rb
@@ -81,6 +81,19 @@ describe 'items details', type: :feature do
     expect(page).not_to have_content('9')
   end
 
+  it 'blocks an invalid price' do
+    visit_items_details_page_in_form do
+      fill_in('id', with: '567')
+      fill_in('name', with: 'Part')
+      fill_in('price', with: '12.50l')
+      fill_in('quantity', with: '9')
+    end
+    expect(page).not_to have_content('567')
+    expect(page).not_to have_content('Part')
+    expect(page).not_to have_content('12.50l')
+    expect(page).not_to have_content('9')
+  end
+
   it 'blocks an invalid quantity' do
     visit_items_details_page_in_form do
       fill_in('id', with: '567')

--- a/spec/unit/use_cases/save_items_details_spec.rb
+++ b/spec/unit/use_cases/save_items_details_spec.rb
@@ -45,6 +45,14 @@ describe SaveItemsDetails do
     )
   end
 
+  it 'returns an error for a different invalid price' do
+    response = use_case.execute(item_details: { id: '12', name: 'Bobs', price: '10.90l', quantity: '10' })
+    expect(response).to eq(
+      successful: false,
+      errors: [:invalid_price]
+    )
+  end
+
   it 'returns an error for invalid quantity' do
     response = use_case.execute(item_details: { id: '12', name: 'Bobs', price: '12.00', quantity: 'Bots' })
     expect(response).to eq(


### PR DESCRIPTION
**What:**
This PR corrects an edge case that appeared during showcase with client.

**Before:**
![image](https://user-images.githubusercontent.com/20663545/45621020-c6dbc900-ba76-11e8-8c33-489775d025c1.png)
![image](https://user-images.githubusercontent.com/20663545/45622853-5b492a00-ba7d-11e8-9bb7-4a6574c97190.png)


**After:**
![image](https://user-images.githubusercontent.com/20663545/45621031-d1965e00-ba76-11e8-97cb-2aac8e0715c6.png)
![image](https://user-images.githubusercontent.com/20663545/45622860-600dde00-ba7d-11e8-8f08-bc542e6df5fc.png)


**Summary of commits:**
- [443e30a](https://github.com/madetech/parts-unlimited-ecom/commit/443e30a62030ecde4c4d21b9840589be14b88fbc) modifies the regex that manages our price validation to only allow:
  - any number of digits
OR
  - a single period between any number of digits

and adds tests to the use case and UI to check for the edge case going forwards.
- [5732009](https://github.com/madetech/parts-unlimited-ecom/pull/20/commits/57320098fb1c2504414b17c6ba2e02bd519a1249) updates the corrected regex based upon suggestion by @rebeccafitzsimmons1 . Improves readability of the regex whilst retaining the functionality. Also excludes non-arabic numerals from being entered.
- [bc45699](https://github.com/madetech/parts-unlimited-ecom/pull/20/commits/bc4569905aeba6d4d954923f2be273218078754e) applies the regex changes from the price validation to the quantity validation as these should be following the same method.

**How to review this PR:**
Please let me know if the regex change makes sense.
In addition, any refactors or optimisation related to the change is appreciated.

**Who should review this PR**
- Anyone within the Academy.
- Anyone willing to provide some feeback.