### PR TITLE
Split customer name into shipping and billing variants

### DIFF
--- a/lib/builder/customer.rb
+++ b/lib/builder/customer.rb
@@ -3,7 +3,7 @@
 module Builder
   class Customer
     attr_accessor :customer_details,
-                  :customer_name,
+                  :shipping_customer_name,
                   :shipping_address_line1,
                   :shipping_address_line2,
                   :shipping_city,
@@ -11,6 +11,7 @@ module Builder
                   :shipping_postcode,
                   :shipping_phone_number,
                   :shipping_email_address,
+                  :billing_customer_name,
                   :billing_address_line1,
                   :billing_address_line2,
                   :billing_city,
@@ -22,7 +23,6 @@ module Builder
     def build
       copy_from_individual_fields unless customer_details_is_used?
       customer = ::Customer.new
-      customer.customer_name = customer_details[:customer_name]
       customer.shipping_address = build_shipping_address
       customer.billing_address = build_billing_address
       customer
@@ -32,6 +32,7 @@ module Builder
 
     def build_shipping_address
       shipping_address = ::Address.new
+      shipping_address.customer_name = customer_details[:shipping_customer_name]
       shipping_address.address_line1 = customer_details[:shipping_address_line1]
       shipping_address.address_line2 = customer_details[:shipping_address_line2]
       shipping_address.city = customer_details[:shipping_city]
@@ -44,6 +45,7 @@ module Builder
 
     def build_billing_address
       billing_address = ::Address.new
+      billing_address.customer_name = customer_details[:billing_customer_name]
       billing_address.address_line1 = customer_details[:billing_address_line1]
       billing_address.address_line2 = customer_details[:billing_address_line2]
       billing_address.city = customer_details[:billing_city]
@@ -60,7 +62,7 @@ module Builder
 
     def copy_from_individual_fields
       @customer_details = {
-        customer_name: customer_name,
+        shipping_customer_name: shipping_customer_name,
         shipping_address_line1: shipping_address_line1,
         shipping_address_line2: shipping_address_line2,
         shipping_city: shipping_city,
@@ -68,6 +70,7 @@ module Builder
         shipping_postcode: shipping_postcode,
         shipping_phone_number: shipping_phone_number,
         shipping_email_address: shipping_email_address,
+        billing_customer_name: billing_customer_name,
         billing_address_line1: billing_address_line1,
         billing_address_line2: billing_address_line2,
         billing_city: billing_city,

--- a/lib/domain/address.rb
+++ b/lib/domain/address.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Address
-  attr_accessor :address_line1,
+  attr_accessor :customer_name,
+                :address_line1,
                 :address_line2,
                 :city,
                 :county,

--- a/lib/domain/customer.rb
+++ b/lib/domain/customer.rb
@@ -2,6 +2,7 @@
 
 class Customer
   extend Forwardable
+  def_delegator :@shipping_address, :customer_name, :shipping_customer_name
   def_delegator :@shipping_address, :address_line1, :shipping_address_line1
   def_delegator :@shipping_address, :address_line2, :shipping_address_line2
   def_delegator :@shipping_address, :city, :shipping_city
@@ -9,6 +10,7 @@ class Customer
   def_delegator :@shipping_address, :postcode, :shipping_postcode
   def_delegator :@shipping_address, :phone_number, :shipping_phone_number
   def_delegator :@shipping_address, :email_address, :shipping_email_address
+  def_delegator :@billing_address, :customer_name, :billing_customer_name
   def_delegator :@billing_address, :address_line1, :billing_address_line1
   def_delegator :@billing_address, :address_line2, :billing_address_line2
   def_delegator :@billing_address, :city, :billing_city
@@ -17,7 +19,6 @@ class Customer
   def_delegator :@billing_address, :phone_number, :billing_phone_number
   def_delegator :@billing_address, :email_address, :billing_email_address
 
-  attr_accessor :customer_name,
-                :shipping_address,
+  attr_accessor :shipping_address,
                 :billing_address
 end

--- a/lib/file_customer_gateway.rb
+++ b/lib/file_customer_gateway.rb
@@ -16,7 +16,7 @@ class FileCustomerGateway
 
   def save(customer)
     serialised_customer = {
-      customer_name: customer.customer_name,
+      shipping_customer_name: customer.shipping_customer_name,
       shipping_address_line1: customer.shipping_address_line1,
       shipping_address_line2: customer.shipping_address_line2,
       shipping_city: customer.shipping_city,
@@ -24,6 +24,7 @@ class FileCustomerGateway
       shipping_postcode: customer.shipping_postcode,
       shipping_phone_number: customer.shipping_phone_number,
       shipping_email_address: customer.shipping_email_address,
+      billing_customer_name: customer.billing_customer_name,
       billing_address_line1: customer.billing_address_line1,
       billing_address_line2: customer.billing_address_line2,
       billing_city: customer.billing_city,

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -37,7 +37,7 @@ get '/customer-details' do
 end
 
 post '/customer-details' do
-  customer_name = params.fetch(:customer_name)
+  shipping_customer_name = params.fetch(:shipping_customer_name)
   shipping_address_line1 = params.fetch(:shipping_address_line1)
   shipping_address_line2 = params.fetch(:shipping_address_line2)
   shipping_city = params.fetch(:shipping_city)
@@ -45,6 +45,7 @@ post '/customer-details' do
   shipping_postcode = params.fetch(:shipping_postcode)
   shipping_phone_number = params.fetch(:shipping_phone_number)
   shipping_email_address = params.fetch(:shipping_email_address)
+  billing_customer_name = params.fetch(:billing_customer_name)
   billing_address_line1 = params.fetch(:billing_address_line1)
   billing_address_line2 = params.fetch(:billing_address_line2)
   billing_city = params.fetch(:billing_city)
@@ -53,7 +54,7 @@ post '/customer-details' do
   billing_phone_number = params.fetch(:billing_phone_number)
   billing_email_address = params.fetch(:billing_email_address)
   @customer_details = {
-    customer_name: customer_name,
+    shipping_customer_name: shipping_customer_name,
     shipping_address_line1: shipping_address_line1,
     shipping_address_line2: shipping_address_line2,
     shipping_city: shipping_city,
@@ -61,6 +62,7 @@ post '/customer-details' do
     shipping_postcode: shipping_postcode,
     shipping_phone_number: shipping_phone_number,
     shipping_email_address: shipping_email_address,
+    billing_customer_name: billing_customer_name,
     billing_address_line1: billing_address_line1,
     billing_address_line2: billing_address_line2,
     billing_city: billing_city,

--- a/lib/use_cases/view_summary.rb
+++ b/lib/use_cases/view_summary.rb
@@ -16,7 +16,7 @@ class ViewSummary
   def customer
     return nil if @customer_gateway.all.empty?
     customer = @customer_gateway.all.first
-    { customer_name: customer.customer_name,
+    { shipping_customer_name: customer.shipping_customer_name,
       shipping_address_line1: customer.shipping_address_line1,
       shipping_address_line2: customer.shipping_address_line2,
       shipping_city: customer.shipping_city,
@@ -24,6 +24,7 @@ class ViewSummary
       shipping_postcode: customer.shipping_postcode,
       shipping_phone_number: customer.shipping_phone_number,
       shipping_email_address: customer.shipping_email_address,
+      billing_customer_name: customer.billing_customer_name,
       billing_address_line1: customer.billing_address_line1,
       billing_address_line2: customer.billing_address_line2,
       billing_city: customer.billing_city,

--- a/lib/views/customer_details.erb
+++ b/lib/views/customer_details.erb
@@ -26,19 +26,19 @@
         <div class="col-6">
           <% if @customer_details.nil? %>
           <form class="pt-5" method="POST" action="/customer-details">
+            <h3 class="pt-1 pb-1"> Shipping Details </h3>
             <div class="form-group">
-              <label for="customer-name">Customer Name<span class="text-danger">*</span></label>
+              <label for="shipping-customer-name">Shipping Customer Name<span class="text-danger">*</span></label>
               <input
                 type="text"
                 class="form-control"
-                id="customer-name"
-                name="customer_name"
+                id="shipping-customer-name"
+                name="shipping_customer_name"
                 />
               <%if @errors.include?(:missing_customer_name)%>
               <p class="text-danger">Please enter a customer name</p>
               <%end%>
             </div>
-            <h3 class="pt-1 pb-1"> Shipping Details </h3>
             <div class="form-group">
               <label for="shipping-address-line1">Address Line 1<span class="text-danger">*</span></label>
               <input
@@ -127,6 +127,18 @@
               <%end%>
             </div>
             <h3 class="pt-1 pb-1"> Billing Details </h3>
+            <div class="form-group">
+              <label for="billing-customer-name">Billing Customer Name<span class="text-danger">*</span></label>
+              <input
+                type="text"
+                class="form-control"
+                id="billing-customer-name"
+                name="billing_customer_name"
+                />
+              <%if @errors.include?(:missing_customer_name)%>
+              <p class="text-danger">Please enter a customer name</p>
+              <%end%>
+            </div>
             <div class="form-group">
               <label for="billing-address-line1">Address Line 1<span class="text-danger">*</span></label>
               <input
@@ -218,20 +230,20 @@
           </form>
           <% else %>
           <form class="pt-5" method="POST" action="/customer-details">
+            <h3 class="pt-1 pb-1"> Shipping Details </h3>
             <div class="form-group">
-              <label for="customer-name">Customer Name<span class="text-danger">*</span></label>
+              <label for="shipping-customer-name">Customer Name<span class="text-danger">*</span></label>
               <input
                 type="text"
                 class="form-control"
-                id="customer-name"
-                name="customer_name"
-                value="<%= @customer_details[:customer_name] %>"
+                id="shipping-customer-name"
+                name="shipping_customer_name"
+                value="<%= @customer_details[:shipping_customer_name] %>"
                 />
               <%if @errors.include?(:missing_customer_name)%>
               <p class="text-danger">Please enter a customer name</p>
               <%end%>
             </div>
-            <h3 class="pt-1 pb-1"> Shipping Details </h3>
             <div class="form-group">
               <label for="shipping-address-line1">Address Line 1<span class="text-danger">*</span></label>
               <input
@@ -327,6 +339,19 @@
               <%end%>
             </div>
             <h3 class="pt-1 pb-1"> Billing Details </h3>
+            <div class="form-group">
+              <label for="billing-customer-name">Customer Name<span class="text-danger">*</span></label>
+              <input
+                type="text"
+                class="form-control"
+                id="billing-customer-name"
+                name="billing_customer_name"
+                value="<%= @customer_details[:billing_customer_name] %>"
+                />
+              <%if @errors.include?(:missing_customer_name)%>
+              <p class="text-danger">Please enter a customer name</p>
+              <%end%>
+            </div>
             <div class="form-group">
               <label for="billing-address-line1">Address Line 1<span class="text-danger">*</span></label>
               <input

--- a/lib/views/customer_details.erb
+++ b/lib/views/customer_details.erb
@@ -28,7 +28,7 @@
           <form class="pt-5" method="POST" action="/customer-details">
             <h3 class="pt-1 pb-1"> Shipping Details </h3>
             <div class="form-group">
-              <label for="shipping-customer-name">Shipping Customer Name<span class="text-danger">*</span></label>
+              <label for="shipping-customer-name">Shipping Name<span class="text-danger">*</span></label>
               <input
                 type="text"
                 class="form-control"
@@ -128,7 +128,7 @@
             </div>
             <h3 class="pt-1 pb-1"> Billing Details </h3>
             <div class="form-group">
-              <label for="billing-customer-name">Billing Customer Name<span class="text-danger">*</span></label>
+              <label for="billing-customer-name">Billing Name<span class="text-danger">*</span></label>
               <input
                 type="text"
                 class="form-control"
@@ -232,7 +232,7 @@
           <form class="pt-5" method="POST" action="/customer-details">
             <h3 class="pt-1 pb-1"> Shipping Details </h3>
             <div class="form-group">
-              <label for="shipping-customer-name">Customer Name<span class="text-danger">*</span></label>
+              <label for="shipping-customer-name">Shipping Name<span class="text-danger">*</span></label>
               <input
                 type="text"
                 class="form-control"
@@ -340,7 +340,7 @@
             </div>
             <h3 class="pt-1 pb-1"> Billing Details </h3>
             <div class="form-group">
-              <label for="billing-customer-name">Customer Name<span class="text-danger">*</span></label>
+              <label for="billing-customer-name">Billing Name<span class="text-danger">*</span></label>
               <input
                 type="text"
                 class="form-control"

--- a/lib/views/summary.erb
+++ b/lib/views/summary.erb
@@ -21,7 +21,7 @@
       </div>
       <div class="row">
         <div class="col pt-5">
-          <h1 style="text-align:center;"><%= @customer[:customer_name] %>'s Order Summary</h1>
+          <h1 style="text-align:center;"><%= @customer[:shipping_customer_name] %>'s Order Summary</h1>
         </div>
       </div>
       <div class="row">
@@ -32,12 +32,14 @@
               <div class="col-4 rounded pt-2 bg-white" >
                 <h3 style="text-align:center;">Billing Details</h3>
                 <br/>
-                <p> <%= @customer[:billing_address_line1] %> <br/>
-                  <%= @customer[:billing_address_line2] %>  <br/>
-                  <%= @customer[:billing_city] %>  <br/>
-                  <%= @customer[:billing_county] %>  <br/>
-                  <%= @customer[:billing_postcode] %>  <br/> <br/>
-                  <%= @customer[:billing_phone_number] %>  <br/>
+                <p>
+                  <%= @customer[:billing_customer_name] %> </br>
+                  <%= @customer[:billing_address_line1] %> <br/>
+                  <%= @customer[:billing_address_line2] %> <br/>
+                  <%= @customer[:billing_city] %> <br/>
+                  <%= @customer[:billing_county] %> <br/>
+                  <%= @customer[:billing_postcode] %> <br/> <br/>
+                  <%= @customer[:billing_phone_number] %> <br/>
                   <%= @customer[:billing_email_address] %>
                 </p>
               </div>
@@ -46,7 +48,9 @@
               <div class="col-4 pt-2 bg-white rounded" >
                 <h3 style="text-align:center;">Shipping Details</h3>
                 <br/>
-                <p> <%= @customer[:shipping_address_line1] %> <br/>
+                <p>
+                  <%= @customer[:shipping_customer_name] %> <br/>
+                  <%= @customer[:shipping_address_line1] %> <br/>
                   <%= @customer[:shipping_address_line2] %>  <br/>
                   <%= @customer[:shipping_city] %>  <br/>
                   <%= @customer[:shipping_county] %>  <br/>

--- a/spec/acceptance/place_order_spec.rb
+++ b/spec/acceptance/place_order_spec.rb
@@ -16,7 +16,7 @@ describe 'place order' do
     context 'given valid customer details' do
       it 'stores the customer details' do
         customer_details = {
-          customer_name: 'Barry',
+          shipping_customer_name: 'Barry',
           shipping_address_line1: '136 Southwark Street',
           shipping_address_line2: 'Southwark',
           shipping_city: 'London',
@@ -24,6 +24,7 @@ describe 'place order' do
           shipping_postcode: 'SE1 0SW',
           shipping_phone_number: '07912345671',
           shipping_email_address: 'barry@gmail.com',
+          billing_customer_name: 'Barry',
           billing_address_line1: '136 Southwark Street',
           billing_address_line2: 'Southwark',
           billing_city: 'London',
@@ -36,7 +37,7 @@ describe 'place order' do
         save_customer_details.execute(customer_details: customer_details)
 
         customer = customer_gateway.all.first
-        expect(customer.customer_name).to eq('Barry')
+        expect(customer.shipping_customer_name).to eq('Barry')
         expect(customer.shipping_address_line1).to eq('136 Southwark Street')
         expect(customer.shipping_address_line2).to eq('Southwark')
         expect(customer.shipping_city).to eq('London')
@@ -44,6 +45,7 @@ describe 'place order' do
         expect(customer.shipping_postcode).to eq('SE1 0SW')
         expect(customer.shipping_phone_number).to eq('07912345671')
         expect(customer.shipping_email_address).to eq('barry@gmail.com')
+        expect(customer.billing_customer_name).to eq('Barry')
         expect(customer.billing_address_line1).to eq('136 Southwark Street')
         expect(customer.billing_address_line2).to eq('Southwark')
         expect(customer.billing_city).to eq('London')
@@ -57,7 +59,7 @@ describe 'place order' do
     context 'given invalid customer details' do
       it 'responds with a validation error' do
         customer_details = {
-          customer_name: '',
+          shipping_customer_name: '',
           shipping_address_line1: '',
           shipping_address_line2: 'Hey',
           shipping_city: '',
@@ -65,6 +67,7 @@ describe 'place order' do
           shipping_postcode: 'S2E1 0SW',
           shipping_phone_number: '07912345671765',
           shipping_email_address: 'barrygmail.com',
+          billing_customer_name: '',
           billing_address_line1: '',
           billing_address_line2: 'Southwark',
           billing_city: '',
@@ -78,10 +81,11 @@ describe 'place order' do
           eq(
             successful: false,
             errors: %i[
-              missing_customer_name
+              missing_shipping_customer_name
               missing_shipping_address_line1
               missing_shipping_city
               missing_shipping_county
+              missing_billing_customer_name
               missing_billing_address_line1
               missing_billing_city
               missing_billing_county
@@ -101,7 +105,7 @@ describe 'place order' do
   context 'viewing order summary'  do
     it 'displays customer details' do
       customer_details = {
-        customer_name: 'Barry',
+        shipping_customer_name: 'Barry',
         shipping_address_line1: '136 Southwark Street',
         shipping_address_line2: 'Southwark',
         shipping_city: 'London',
@@ -109,6 +113,7 @@ describe 'place order' do
         shipping_postcode: 'SE1 0SW',
         shipping_phone_number: '07912345671',
         shipping_email_address: 'barry@gmail.com',
+        billing_customer_name: 'Barry',
         billing_address_line1: '136 Southwark Street',
         billing_address_line2: 'Southwark',
         billing_city: 'London',

--- a/spec/ui/customer_details_spec.rb
+++ b/spec/ui/customer_details_spec.rb
@@ -12,7 +12,7 @@ describe 'customer details', type: :feature do
   end
 
   it 'accepts a customer name' do
-    visit_customer_details_page_in_form { fill_in('customer_name', with: 'Larry') }
+    visit_customer_details_page_in_form { fill_in('shipping_customer_name', with: 'Larry') }
     expect(page).to have_no_content('Please enter a customer name')
   end
 
@@ -33,7 +33,7 @@ describe 'customer details', type: :feature do
 
   it 'goes to the add items page' do
     visit_customer_details_page_in_form do
-      fill_in('customer_name', with: 'Bob')
+      fill_in('shipping_customer_name', with: 'Bob')
       fill_in('shipping_address_line1', with: '1 Fake Street')
       fill_in('shipping_address_line2', with: 'Fake Flat')
       fill_in('shipping_city', with: 'Faketon')
@@ -41,6 +41,7 @@ describe 'customer details', type: :feature do
       fill_in('shipping_postcode', with: 'FK1 1SW')
       fill_in('shipping_phone_number', with: '01828381828')
       fill_in('shipping_email_address', with: 'fake@gmail.com')
+      fill_in('billing_customer_name', with: 'Bob')
       fill_in('billing_address_line1', with: '12 Fakeish')
       fill_in('billing_address_line2', with: 'Fake block')
       fill_in('billing_city', with: 'Fakeville')
@@ -54,7 +55,7 @@ describe 'customer details', type: :feature do
 
   it 'keeps content on the page if there is an invalid entry' do
     visit_customer_details_page_in_form do
-      fill_in('customer_name', with: 'Bob')
+      fill_in('shipping_customer_name', with: 'Bob')
       fill_in('shipping_address_line1', with: '1 Fake Street')
       fill_in('shipping_address_line2', with: 'Fake Flat')
       fill_in('shipping_city', with: 'Faketon')
@@ -62,6 +63,7 @@ describe 'customer details', type: :feature do
       fill_in('shipping_postcode', with: 'FK1 1SW')
       fill_in('shipping_phone_number', with: '01828381')
       fill_in('shipping_email_address', with: 'fake@gmail.com')
+      fill_in('billing_customer_name', with: 'Bob')
       fill_in('billing_address_line1', with: '12 Fakeish')
       fill_in('billing_address_line2', with: 'Fake block')
       fill_in('billing_city', with: 'Fakeville')
@@ -70,7 +72,7 @@ describe 'customer details', type: :feature do
       fill_in('billing_phone_number', with: '01982371234')
       fill_in('billing_email_address', with: 'fake2@gmail.com')
     end
-    expect(find_field('customer_name').value).to eq('Bob')
+    expect(find_field('shipping_customer_name').value).to eq('Bob')
     expect(find_field('shipping_address_line1').value).to eq('1 Fake Street')
     expect(find_field('shipping_address_line2').value).to eq('Fake Flat')
     expect(find_field('shipping_city').value).to eq('Faketon')
@@ -78,6 +80,7 @@ describe 'customer details', type: :feature do
     expect(find_field('shipping_postcode').value).to eq('FK1 1SW')
     expect(find_field('shipping_phone_number').value).to eq('01828381')
     expect(find_field('shipping_email_address').value).to eq('fake@gmail.com')
+    expect(find_field('billing_customer_name').value).to eq('Bob')
     expect(find_field('billing_address_line1').value).to eq('12 Fakeish')
     expect(find_field('billing_address_line2').value).to eq('Fake block')
     expect(find_field('billing_city').value).to eq('Fakeville')

--- a/spec/unit/file_customer_gateway_spec.rb
+++ b/spec/unit/file_customer_gateway_spec.rb
@@ -14,7 +14,7 @@ describe FileCustomerGateway do
   it 'can get a customer' do
     customer_builder = Builder::Customer.new
 
-    customer_builder.customer_name = 'Bob'
+    customer_builder.shipping_customer_name = 'Bob'
     customer_builder.shipping_address_line1 = '1 Fake Street'
     customer_builder.shipping_address_line2 = 'Fake Flat'
     customer_builder.shipping_city = 'Faketon'
@@ -22,6 +22,7 @@ describe FileCustomerGateway do
     customer_builder.shipping_postcode = 'FK1 1SW'
     customer_builder.shipping_phone_number = '018283818283'
     customer_builder.shipping_email_address = 'fake@gmail.com'
+    customer_builder.billing_customer_name = 'Bob'
     customer_builder.billing_address_line1 = '12 Fakeish'
     customer_builder.billing_address_line2 = 'Fake block'
     customer_builder.billing_city = 'Fakeville'
@@ -33,7 +34,7 @@ describe FileCustomerGateway do
     file_customer_gateway.save(customer)
 
     file_customer_gateway.all.first.tap do |customer|
-      expect(customer.customer_name).to eq('Bob')
+      expect(customer.shipping_customer_name).to eq('Bob')
       expect(customer.shipping_address_line1).to eq('1 Fake Street')
       expect(customer.shipping_address_line2).to eq('Fake Flat')
       expect(customer.shipping_city).to eq('Faketon')
@@ -41,6 +42,7 @@ describe FileCustomerGateway do
       expect(customer.shipping_postcode).to eq('FK1 1SW')
       expect(customer.shipping_phone_number).to eq('018283818283')
       expect(customer.shipping_email_address).to eq('fake@gmail.com')
+      expect(customer.billing_customer_name).to eq('Bob')
       expect(customer.billing_address_line1).to eq('12 Fakeish')
       expect(customer.billing_address_line2).to eq('Fake block')
       expect(customer.billing_city).to eq('Fakeville')

--- a/spec/unit/use_cases/save_customer_details_spec.rb
+++ b/spec/unit/use_cases/save_customer_details_spec.rb
@@ -8,7 +8,7 @@ describe SaveCustomerDetails do
 
   it 'uses the customer gateway to save customer details' do
     use_case.execute(customer_details: {
-                       customer_name: 'Paul',
+                       shipping_customer_name: 'Paul',
                        shipping_address_line1: '137 Southwark Street',
                        shipping_address_line2: 'Northwark',
                        shipping_city: 'Kent',
@@ -16,6 +16,7 @@ describe SaveCustomerDetails do
                        shipping_postcode: 'S21 0SW',
                        shipping_phone_number: '07912345672',
                        shipping_email_address: 'paul@gmail.com',
+                       billing_customer_name: 'Paul',
                        billing_address_line1: '137 Southwark Street',
                        billing_address_line2: 'Northwark',
                        billing_city: 'Kent',
@@ -26,7 +27,7 @@ describe SaveCustomerDetails do
                      })
 
     expect(customer_gateway).to have_received(:save) do |customer|
-      expect(customer.customer_name).to eq('Paul')
+      expect(customer.shipping_customer_name).to eq('Paul')
       expect(customer.shipping_address_line1).to eq('137 Southwark Street')
       expect(customer.shipping_address_line2).to eq('Northwark')
       expect(customer.shipping_city).to eq('Kent')
@@ -34,6 +35,7 @@ describe SaveCustomerDetails do
       expect(customer.shipping_postcode).to eq('S21 0SW')
       expect(customer.shipping_phone_number).to eq('07912345672')
       expect(customer.shipping_email_address).to eq('paul@gmail.com')
+      expect(customer.billing_customer_name).to eq('Paul')
       expect(customer.billing_address_line1).to eq('137 Southwark Street')
       expect(customer.billing_address_line2).to eq('Northwark')
       expect(customer.billing_city).to eq('Kent')
@@ -47,7 +49,7 @@ describe SaveCustomerDetails do
   context 'validate customer details' do
     it 'can return success for valid details' do
       response = use_case.execute(customer_details: {
-                                    customer_name: 'Harry',
+                                    shipping_customer_name: 'Harry',
                                     shipping_address_line1: '13 South Street',
                                     shipping_address_line2: 'Borough',
                                     shipping_city: 'Fake',
@@ -55,6 +57,7 @@ describe SaveCustomerDetails do
                                     shipping_postcode: 'N21 0SW',
                                     shipping_phone_number: '07912456672',
                                     shipping_email_address: 'harry@gmail.com',
+                                    billing_customer_name: 'Harry',
                                     billing_address_line1: '13 South Street',
                                     billing_address_line2: 'Borough',
                                     billing_city: 'Fake',

--- a/spec/unit/use_cases/view_summary_spec.rb
+++ b/spec/unit/use_cases/view_summary_spec.rb
@@ -26,13 +26,14 @@ describe ViewSummary do
 
   class CustomerStub
     def initialize(
-      customer_name,
+      shipping_customer_name,
       shipping_address_line1,
       shipping_city,
       shipping_county,
       shipping_postcode,
       shipping_phone_number,
       shipping_email_address,
+      billing_customer_name,
       billing_address_line1,
       billing_city,
       billing_county,
@@ -40,13 +41,14 @@ describe ViewSummary do
       billing_phone_number,
       billing_email_address
     )
-      @customer_name = customer_name
+      @shipping_customer_name = shipping_customer_name
       @shipping_address_line1 = shipping_address_line1
       @shipping_city = shipping_city
       @shipping_county = shipping_county
       @shipping_postcode = shipping_postcode
       @shipping_phone_number = shipping_phone_number
       @shipping_email_address = shipping_email_address
+      @billing_customer_name = billing_customer_name
       @billing_address_line1 = billing_address_line1
       @billing_city = billing_city
       @billing_county = billing_county
@@ -55,7 +57,7 @@ describe ViewSummary do
       @billing_email_address = billing_email_address
     end
 
-    attr_reader :customer_name,
+    attr_reader :shipping_customer_name,
                 :shipping_address_line1,
                 :shipping_address_line2,
                 :shipping_city,
@@ -63,6 +65,7 @@ describe ViewSummary do
                 :shipping_postcode,
                 :shipping_phone_number,
                 :shipping_email_address,
+                :billing_customer_name,
                 :billing_address_line1,
                 :billing_address_line2,
                 :billing_city,
@@ -81,6 +84,7 @@ describe ViewSummary do
       'LN1 2DZ',
       '01234567890',
       'harry@southwark.com',
+      'Harry',
       'Southwark',
       'London',
       'Greater London',
@@ -104,7 +108,8 @@ describe ViewSummary do
       shipping_postcode: 'LN1 2DZ',
       billing_phone_number: '01234567890',
       billing_postcode: 'LN1 2DZ',
-      customer_name: 'Harry',
+      shipping_customer_name: 'Harry',
+      billing_customer_name: 'Harry',
       shipping_address_line1: 'Southwark',
       shipping_address_line2: nil,
       shipping_city: 'London',


### PR DESCRIPTION
**What:**
This PR applies the request from the client showcase to split customer name on the customer details page into a 'Shipping Customer Name' and 'Billing Customer Name'

**Before:**
![image](https://user-images.githubusercontent.com/20663545/45629154-9c493a80-ba8d-11e8-9d84-c33ac84d8927.png)

**After:**
![image](https://user-images.githubusercontent.com/20663545/45629084-7a4fb800-ba8d-11e8-9119-00f09f7fd693.png)
![image](https://user-images.githubusercontent.com/20663545/45629091-7f146c00-ba8d-11e8-9538-b0208c2648fc.png)

**Summary of commits:**
- [ef7e1ec](https://github.com/madetech/parts-unlimited-ecom/commit/ef7e1ec0641c86a2ec7d4a8ff9abf93a376ebd8d) Splits instances of customer_name into shipping_customer_name and billing_customer_name
- [20640f4](https://github.com/madetech/parts-unlimited-ecom/pull/21/commits/20640f4c15f24925ea07baf31e6fe880df46cfdf) Updates labels for the new name fields to be more consistent.

**How to review this PR:**
Looking for input on whether there are any issues with the way I have updated the code.
Please let me know if there is any redundant code or optimisations.

**Who should review this PR:**
- Anyone from the Academy's input would be helpful
- @craigjbass's input would be welcome as I went into this one a bit blind 