### PR TITLE
Correct call to name validation messages in customer_details.erb

### DIFF
--- a/lib/views/customer_details.erb
+++ b/lib/views/customer_details.erb
@@ -36,7 +36,7 @@
                 value="<%= @customer_details[:shipping_customer_name] %>"
                 />
               <%if @errors.include?(:missing_shipping_customer_name)%>
-              <p class="text-danger">Please enter a customer name</p>
+              <p class="text-danger">Please enter a shipping name</p>
               <%end%>
             </div>
             <div class="form-group">
@@ -144,7 +144,7 @@
                 value="<%= @customer_details[:billing_customer_name] %>"
                 />
               <%if @errors.include?(:missing_billing_customer_name)%>
-              <p class="text-danger">Please enter a customer name</p>
+              <p class="text-danger">Please enter a billing name</p>
               <%end%>
             </div>
             <div class="form-group">

--- a/lib/views/customer_details.erb
+++ b/lib/views/customer_details.erb
@@ -35,7 +35,7 @@
                 name="shipping_customer_name"
                 value="<%= @customer_details[:shipping_customer_name] %>"
                 />
-              <%if @errors.include?(:missing_customer_name)%>
+              <%if @errors.include?(:missing_shipping_customer_name)%>
               <p class="text-danger">Please enter a customer name</p>
               <%end%>
             </div>
@@ -143,7 +143,7 @@
                 name="billing_customer_name"
                 value="<%= @customer_details[:billing_customer_name] %>"
                 />
-              <%if @errors.include?(:missing_customer_name)%>
+              <%if @errors.include?(:missing_billing_customer_name)%>
               <p class="text-danger">Please enter a customer name</p>
               <%end%>
             </div>


### PR DESCRIPTION
**What:**
This PR corrects an issue which prevented the error messages for missing customer and billing names from appearing in the UI.

**Before:**
![image](https://user-images.githubusercontent.com/20663545/45634226-ba1c9c80-ba99-11e8-9d72-0ad6b6c384cb.png)

**After:**
![image](https://user-images.githubusercontent.com/20663545/45634773-25b33980-ba9b-11e8-8a27-83c7a32b50e4.png)


**Summary of commits:**
- [bc98e83](https://github.com/madetech/parts-unlimited-ecom/commit/bc98e83c9da43d2db0b5aebec0f36d08200200e6) changes the reference to `missing_customer_name` to `missing_shipping_customer_name` and `missing_billing_customer_name`.
- [a4c5cf3](https://github.com/madetech/parts-unlimited-ecom/pull/24/commits/a4c5cf3165c26325c0a4337fecd4e391d7882ff6) per @Renny4Real's suggestion, specified which customer name field is missing. 

**How to review this PR:**
Very minor change. Please confirm you're happy the errors messages appear when the branch is run locally?

**Who should review this PR**
- Anyone from the Academy team please.
