### PR TITLE
Change how validation errors are displayed on add items page

### DIFF
--- a/lib/views/items_details.erb
+++ b/lib/views/items_details.erb
@@ -67,11 +67,11 @@
             <div class="form-row">
               <div class="p-1 pl-3 width-14">
                 <% if @errors.include?(:missing_id)%>
-                <input type="text" id="id" name="id" class="form-control is-invalid" placeholder="ID"/>
+                <input autofocus type="text" id="id" name="id" class="form-control is-invalid" placeholder="ID"/>
                 <% elsif @item_row.nil? %>
-                <input type="text" id="id" name="id" class="form-control" placeholder="ID"/>
+                <input autofocus type="text" id="id" name="id" class="form-control" placeholder="ID"/>
                 <% else %>
-                <input type="text" id="id" name="id" class="form-control" value="<%= @item_row[:id]%>"/>
+                <input autofocus type="text" id="id" name="id" class="form-control" value="<%= @item_row[:id]%>"/>
                 <% end %>
               </div>
               <div class="p-1 width-45">

--- a/lib/views/items_details.erb
+++ b/lib/views/items_details.erb
@@ -101,6 +101,21 @@
               </div>
             </div>
           </form>
+              <% pretty_error_message_conversion = { 
+                missing_id: 'Please enter a product ID', 
+                missing_name: 'Please enter a product name',
+                missing_price: 'Please enter a price',
+                missing_quantity: 'Please enter a quantity',
+                invalid_price: 'Please enter a valid price',
+                invalid_quantity: 'Please enter a quantity'
+                } %>
+              <p class="text-danger pl-2">
+              <% @errors.each do |error|%>
+                <% next if error == :invalid_quantity && @errors.include?(:missing_quantity) %>
+                <% next if error == :invalid_price && @errors.include?(:missing_price) %>
+                *<%= pretty_error_message_conversion[error] %><br/>
+              <% end %>
+              </p>
         </div>
         <div class="col-1"></div>
       </div>

--- a/lib/views/items_details.erb
+++ b/lib/views/items_details.erb
@@ -25,25 +25,6 @@
       <div class="row">
         <div class="col-1"></div>
         <div class="col-10 pt-5">
-                    <% pretty_error_message_conversion = { 
-                missing_id: 'Please enter a product ID', 
-                missing_name: 'Please enter a product name',
-                missing_price: 'Please enter a price',
-                missing_quantity: 'Please enter a quantity',
-                invalid_price: 'Please enter a valid price',
-                invalid_quantity: 'Please enter a quantity'
-                }
-            %>
-            <% if @errors.empty? %>
-            <% else %>
-            <div class="alert alert-danger" role="alert">
-          <% @errors.each do |error|%>
-            <% next if error == :invalid_quantity && @errors.include?(:missing_quantity) %>
-            <% next if error == :invalid_price && @errors.include?(:missing_price) %>
-              *<%= pretty_error_message_conversion[error] %><br/>
-          <% end %>
-            </div>
-            <% end %>
           <table class="table table-striped border rounded bg-white">
             <thead>
               <tr>
@@ -77,6 +58,11 @@
       <div class="row">
         <div class="col-1"></div>
         <div class="col-10">
+            <% unless @errors.empty?%>
+            <div class="alert alert-danger" role="alert">
+              *All fields are required.
+            </div>
+            <% end %>
           <form method="POST" action="/items-details" id="new-row">
             <div class="form-row">
               <div class="p-1 pl-3 width-14">

--- a/lib/views/items_details.erb
+++ b/lib/views/items_details.erb
@@ -67,6 +67,8 @@
                 invalid_quantity: 'Please enter a quantity'
                 }
             %>
+            <% if @errors.empty? %>
+            <% else %>
             <div class="alert alert-danger" role="alert">
           <% @errors.each do |error|%>
             <% next if error == :invalid_quantity && @errors.include?(:missing_quantity) %>
@@ -74,6 +76,7 @@
               *<%= pretty_error_message_conversion[error] %><br/>
           <% end %>
             </div>
+            <% end %>
           <form method="POST" action="/items-details" id="new-row">
             <div class="form-row">
               <div class="p-1 pl-3 width-14">

--- a/lib/views/items_details.erb
+++ b/lib/views/items_details.erb
@@ -58,6 +58,22 @@
       <div class="row">
         <div class="col-1"></div>
         <div class="col-10">
+            <% pretty_error_message_conversion = { 
+                missing_id: 'Please enter a product ID', 
+                missing_name: 'Please enter a product name',
+                missing_price: 'Please enter a price',
+                missing_quantity: 'Please enter a quantity',
+                invalid_price: 'Please enter a valid price',
+                invalid_quantity: 'Please enter a quantity'
+                }
+            %>
+            <div class="alert alert-danger" role="alert">
+          <% @errors.each do |error|%>
+            <% next if error == :invalid_quantity && @errors.include?(:missing_quantity) %>
+            <% next if error == :invalid_price && @errors.include?(:missing_price) %>
+              *<%= pretty_error_message_conversion[error] %><br/>
+          <% end %>
+            </div>
           <form method="POST" action="/items-details" id="new-row">
             <div class="form-row">
               <div class="p-1 pl-3 width-14">
@@ -101,21 +117,6 @@
               </div>
             </div>
           </form>
-              <% pretty_error_message_conversion = { 
-                missing_id: 'Please enter a product ID', 
-                missing_name: 'Please enter a product name',
-                missing_price: 'Please enter a price',
-                missing_quantity: 'Please enter a quantity',
-                invalid_price: 'Please enter a valid price',
-                invalid_quantity: 'Please enter a quantity'
-                } %>
-              <p class="text-danger pl-2">
-              <% @errors.each do |error|%>
-                <% next if error == :invalid_quantity && @errors.include?(:missing_quantity) %>
-                <% next if error == :invalid_price && @errors.include?(:missing_price) %>
-                *<%= pretty_error_message_conversion[error] %><br/>
-              <% end %>
-              </p>
         </div>
         <div class="col-1"></div>
       </div>

--- a/lib/views/items_details.erb
+++ b/lib/views/items_details.erb
@@ -25,6 +25,25 @@
       <div class="row">
         <div class="col-1"></div>
         <div class="col-10 pt-5">
+                    <% pretty_error_message_conversion = { 
+                missing_id: 'Please enter a product ID', 
+                missing_name: 'Please enter a product name',
+                missing_price: 'Please enter a price',
+                missing_quantity: 'Please enter a quantity',
+                invalid_price: 'Please enter a valid price',
+                invalid_quantity: 'Please enter a quantity'
+                }
+            %>
+            <% if @errors.empty? %>
+            <% else %>
+            <div class="alert alert-danger" role="alert">
+          <% @errors.each do |error|%>
+            <% next if error == :invalid_quantity && @errors.include?(:missing_quantity) %>
+            <% next if error == :invalid_price && @errors.include?(:missing_price) %>
+              *<%= pretty_error_message_conversion[error] %><br/>
+          <% end %>
+            </div>
+            <% end %>
           <table class="table table-striped border rounded bg-white">
             <thead>
               <tr>
@@ -58,25 +77,6 @@
       <div class="row">
         <div class="col-1"></div>
         <div class="col-10">
-            <% pretty_error_message_conversion = { 
-                missing_id: 'Please enter a product ID', 
-                missing_name: 'Please enter a product name',
-                missing_price: 'Please enter a price',
-                missing_quantity: 'Please enter a quantity',
-                invalid_price: 'Please enter a valid price',
-                invalid_quantity: 'Please enter a quantity'
-                }
-            %>
-            <% if @errors.empty? %>
-            <% else %>
-            <div class="alert alert-danger" role="alert">
-          <% @errors.each do |error|%>
-            <% next if error == :invalid_quantity && @errors.include?(:missing_quantity) %>
-            <% next if error == :invalid_price && @errors.include?(:missing_price) %>
-              *<%= pretty_error_message_conversion[error] %><br/>
-          <% end %>
-            </div>
-            <% end %>
           <form method="POST" action="/items-details" id="new-row">
             <div class="form-row">
               <div class="p-1 pl-3 width-14">


### PR DESCRIPTION
**What:**
Validation errors are now listed in an alert box as well as the form boxes turning red.

**Before:**
<img width="1252" alt="screen shot 2018-09-19 at 10 19 24" src="https://user-images.githubusercontent.com/38878719/45744343-3deb9b80-bbf6-11e8-9dfc-566d6cbe2b7c.png">

**After:**
<img width="1195" alt="screen shot 2018-09-19 at 11 24 46" src="https://user-images.githubusercontent.com/38878719/45747765-c4a47680-bbfe-11e8-9659-04b892a66813.png">


**How to review this PR:**
In particular feedback around the hash I have made which converts the error symbols into user friendly messages would be good. I'm not sure if I've defining it in the right place?

Also feedback on how it looks - don't have to merge it in, if the consensus is that it looked better before!
