### PR TITLE
remove whitespace when saving details

### DIFF
--- a/lib/use_cases/save_customer_details.rb
+++ b/lib/use_cases/save_customer_details.rb
@@ -7,7 +7,8 @@ class SaveCustomerDetails
 
   def execute(customer_details:)
     @customer_details = customer_details
-
+    remove_whitespace
+    
     errors = validate_details
 
     return { successful: false, errors: errors } unless errors.empty?
@@ -21,6 +22,12 @@ class SaveCustomerDetails
   end
 
   private
+
+  def remove_whitespace
+    @customer_details.each_key do |key| 
+      @customer_details[key] = @customer_details[key].strip
+    end
+  end
 
   def validate_details
     errors = check_for_missing_fields

--- a/lib/use_cases/save_items_details.rb
+++ b/lib/use_cases/save_items_details.rb
@@ -7,6 +7,7 @@ class SaveItemsDetails
 
   def execute(item_details:)
     @item_details = item_details
+    remove_whitespace
     errors = validation
 
     return { successful: false, errors: errors } unless errors.empty?
@@ -24,6 +25,12 @@ class SaveItemsDetails
   end
 
   private
+
+  def remove_whitespace
+    @item_details.each_key do |key| 
+      @item_details[key] = @item_details[key].strip
+    end
+  end
 
   def validation
     errors = missing_fields

--- a/spec/unit/use_cases/save_customer_details_spec.rb
+++ b/spec/unit/use_cases/save_customer_details_spec.rb
@@ -341,4 +341,28 @@ describe SaveCustomerDetails do
       expect(response).to eq(successful: false, errors: [:invalid_billing_email_address])
     end
   end
+
+  context 'it will remove whitespace' do
+    it 'returns missing input if only filled with whitespace ' do
+      response = use_case.execute(customer_details: {
+                                    shipping_customer_name: '    ',
+                                    shipping_address_line1: '13 South Street   ',
+                                    shipping_address_line2: 'Borough   ',
+                                    shipping_city: 'Fake',
+                                    shipping_county: '   Manchester',
+                                    shipping_postcode: 'N21 0SW',
+                                    shipping_phone_number: '   07912456672',
+                                    shipping_email_address: 'harry@gmail.com',
+                                    billing_customer_name: 'Harry',
+                                    billing_address_line1: '13 South Street',
+                                    billing_address_line2: 'Borough',
+                                    billing_city: 'Fake',
+                                    billing_county: 'Manchester',
+                                    billing_postcode: 'N21 0SW',
+                                    billing_phone_number: '07912456672',
+                                    billing_email_address: 'harry@gmail.com'
+                                  })
+      expect(response).to eq(successful: false, errors: [:missing_shipping_customer_name])
+    end
+  end
 end

--- a/spec/unit/use_cases/save_items_details_spec.rb
+++ b/spec/unit/use_cases/save_items_details_spec.rb
@@ -47,4 +47,12 @@ describe SaveItemsDetails do
       errors: [:invalid_quantity]
     )
   end
+
+  it 'returns an error if only whitespace is there' do
+    response = use_case.execute(item_details: { product_code: '  ', name: 'Bobs', price: '12.00', quantity: '2' })
+    expect(response).to eq(
+      successful: false,
+      errors: [:missing_product_code]
+    )
+  end
 end


### PR DESCRIPTION
WHAT

Previously you could submit just spaces with no validation errors. We've now changed this.